### PR TITLE
Fix hopper crash by removing unintended WorldlyContainer implementation

### DIFF
--- a/src/main/java/com/dremixam/pastureLoot/mixin/PokemonPastureBlockEntityMixin.java
+++ b/src/main/java/com/dremixam/pastureLoot/mixin/PokemonPastureBlockEntityMixin.java
@@ -11,7 +11,6 @@ import com.dremixam.pastureLoot.Config;
 import com.dremixam.pastureLoot.PastureLoot;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -29,7 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @Mixin(PokemonPastureBlockEntity.class)
-public abstract class PokemonPastureBlockEntityMixin implements WorldlyContainer {
+public abstract class PokemonPastureBlockEntityMixin{
 
     @Unique
     private static final Logger LOGGER = PastureLoot.LOGGER;


### PR DESCRIPTION
This PR fixes a crash when hoppers interact with the Pasture block.

`PokemonPastureBlockEntityMixin` declares implements `WorldlyContainer`, which causes Minecraft to treat `PokemonPastureBlockEntity` as supporting hopper-style item interaction. However, neither the mixin nor the base block entity implement the required `WorldlyContainer` methods (`getSlotsForFace`, `canPlaceItemThroughFace`, `canTakeItemThroughFace`).

When a hopper queries the block entity for slot access, this results in an `AbstractMethodError`.

Removing the `WorldlyContainer` implementation prevents Minecraft from calling methods that are not implemented and resolves the crash. This does not change intended gameplay behaviour.

Note: the crash may not occur when Cobbreeding is installed, as that mod provides these methods, but PastureLoot should not rely on another mod to fulfill this interface.

This removes this mod's dependency on Cobbreeding.